### PR TITLE
Pin Y.js versions and fix minor compilation issues

### DIFF
--- a/packages/codeeditor/tsconfig.json
+++ b/packages/codeeditor/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {

--- a/packages/codeeditor/tsconfig.test.json
+++ b/packages/codeeditor/tsconfig.test.json
@@ -9,6 +9,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {
@@ -28,6 +31,9 @@
     },
     {
       "path": "../nbformat"
+    },
+    {
+      "path": "../nbmodel"
     },
     {
       "path": "../observables"

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@lumino/widgets": "^1.18.0",
     "codemirror": "~5.57.0",
     "react": "^17.0.1",
-    "y-codemirror": "^2.1.0"
+    "y-codemirror": "2.0.9"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -207,7 +207,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     });
   }
 
-  private yeditorBinding: CodemirrorBinding;
+  private yeditorBinding: CodemirrorBinding | null;
   /**
    * A signal emitted when either the top or bottom edge is requested.
    */

--- a/packages/codemirror/tsconfig.json
+++ b/packages/codemirror/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {

--- a/packages/codemirror/tsconfig.test.json
+++ b/packages/codemirror/tsconfig.test.json
@@ -15,6 +15,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {
@@ -40,6 +43,9 @@
     },
     {
       "path": "../nbformat"
+    },
+    {
+      "path": "../nbmodel"
     },
     {
       "path": "../observables"

--- a/packages/nbmodel/package.json
+++ b/packages/nbmodel/package.json
@@ -43,12 +43,13 @@
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
-    "y-protocols": "^1.0.4",
-    "yjs": "^13.5.2"
+    "y-protocols": "1.0.2",
+    "yjs": "13.4.12"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",
     "@types/jest": "^26.0.10",
+    "isomorphic.js": "0.1.5",
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9517,6 +9517,11 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+isomorphic.js@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.1.5.tgz#f210e58ba4c96978a991c443cf67283366e9b70f"
+  integrity sha512-MkX5lLQApx/8IAIU31PKvpAZosnu2Jqcj1rM8TzxyA4CR96tv3SgMKQNTCxL58G7696Q57zd7ubHV/hTg+5fNA==
+
 isomorphic.js@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.2.tgz#4c76fb70d3e207123dead08675ba97eb75f5615a"
@@ -10356,7 +10361,7 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lib0@^0.2.35, lib0@^0.2.38:
+lib0@^0.2.33, lib0@^0.2.35:
   version "0.2.40"
   resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.40.tgz#7c89c2a7a89f9caaa0a04eaecb944d8e90a731b3"
   integrity sha512-bKJxwll8MdwTTL3Siut6L+FjyF5sewXRE7noDTsRquEYy3Xi1UjtdEMZu46iuTvw9nQ/9p+gKkh1GxL2Kdaphw==
@@ -16621,17 +16626,17 @@ xterm@~4.8.1:
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.8.1.tgz#155a1729a43e1a89b406524e22c5634339e39ca1"
   integrity sha512-ax91ny4tI5eklqIfH79OUSGE2PUX2rGbwONmB6DfqpyhSZO8/cf++sqiaMWEVCMjACyMfnISW7C3gGMoNvNolQ==
 
-y-codemirror@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-2.1.0.tgz#905c85fececd6ffa784f9c4bcb69c22ff1ae696e"
-  integrity sha512-lwuXbZoUW1EmhSTFYR7Qkbi01ixn5/L2LpnZ/7/vSRcJL3PKnWLFJOxXdXTx6bNDGUjY8N0VjJe97fYL6ev00Q==
+y-codemirror@2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-2.0.9.tgz#3804c11736b53a71046c23efdbe81128cc850820"
+  integrity sha512-wSSQRGhHKtDdKKjPclhRM3TRg/d1s7kPdzV4nYmVeEsyOZgMWhFxr/23EdSll5r6XUzQ1C3M5YVEQ4SZzhsDDw==
   dependencies:
-    lib0 "^0.2.35"
+    lib0 "^0.2.33"
 
-y-protocols@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.4.tgz#810978c6172474be87457c3bcd669e529c5ba3a1"
-  integrity sha512-5/Hd6DJ5Y2SlbqLIKq86BictdOS0iAcWJZCVop8MKqx0XWwA+BbMn4538n4Z0CGjFMUGnG1kGzagk3BKGz5SvQ==
+y-protocols@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.2.tgz#32c7a2f656b82f435058d28406aa51780a1eb486"
+  integrity sha512-V6ZAmokdogW52+VsIg/YC0R6CHWgG8/hjO3rYL10hAzeT5j464kDiRki31O+GzTj+dMgNYZNd6IDP9X35FLXrw==
   dependencies:
     lib0 "^0.2.35"
 
@@ -16737,9 +16742,9 @@ yarn@1.21.1:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.21.1.tgz#1d5da01a9a03492dc4a5957befc1fd12da83d89c"
   integrity sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==
 
-yjs@^13.5.2:
-  version "13.5.2"
-  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.2.tgz#b518be0df84164591f4cc774aa24468d288e0e75"
-  integrity sha512-X5vscuAhQIYf77xuNeJSlEiQZq0aUVtvs3x2X3//ZGpDqcWiR3D0H1XMDfEnNzdTMzuhfDBMMxSl70klD+0OXw==
+yjs@13.4.12:
+  version "13.4.12"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.4.12.tgz#74e7fe5adaeb0056f500ed3a6765f5de08abfaf1"
+  integrity sha512-ABmFknpmjcGOOWx6m4dTsjEWsN77+jHTI5DbjbwUu5t9ni1teUPOrdZtsNwQDuNPTdwGpiU9MJtIr7W6dgr9aw==
   dependencies:
-    lib0 "^0.2.38"
+    lib0 "^0.2.35"


### PR DESCRIPTION
@dmonad This PR pins down the yjs libraries to avoid 

```
ModuleNotFoundError: Module not found: Error: Can't resolve 'perf_hooks' in ‘.../jupyterlab-rtc/node_modules/isomorphic.js'
at .../node_modules/webpack/lib/Compilation.js:1478:28'
```
It looks the newest yjs pulls a isomporphic.js 0.2.2 which is another beast as 0.1.5 (the 0.2.2 has node.js file which gives issues as jlab3 uses webpack5 where node.js polyfill is not more available).

This PR also fixes minor compilation issues.

With this, I can launch in dev mode and jlab works fine with the first test I have done.