### PR TITLE
Fix codemirror tests

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@lumino/widgets": "^1.18.0",
     "codemirror": "~5.57.0",
     "react": "^17.0.1",
-    "y-codemirror": "2.0.9"
+    "y-codemirror": "^2.1.0"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",

--- a/packages/nbmodel/package.json
+++ b/packages/nbmodel/package.json
@@ -43,8 +43,8 @@
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
-    "y-protocols": "1.0.2",
-    "yjs": "13.4.12"
+    "y-protocols": "^1.0.4",
+    "yjs": "^13.5.2"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",

--- a/packages/nbmodel/package.json
+++ b/packages/nbmodel/package.json
@@ -44,7 +44,7 @@
     "@lumino/disposable": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
     "y-protocols": "^1.0.4",
-    "yjs": "^13.5.2"
+    "yjs": "^13.5.3"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",

--- a/packages/nbmodel/src/ymodel.ts
+++ b/packages/nbmodel/src/ymodel.ts
@@ -111,7 +111,7 @@ export class YNotebook implements nbmodel.ISharedNotebook {
     });
 
     this._changed.emit({
-      cellsChange: event.changes.delta
+      cellsChange: event.changes.delta as any
     });
   };
 
@@ -247,7 +247,11 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     return this.ymodel.get('source').toString();
   }
   public setSource(value: string): void {
-    this.ymodel.set('source', new Y.Text(value));
+    const ytext = this.ymodel.get('source');
+    ytext.delete(0, ytext.length);
+    ytext.insert(0, value);
+    // @todo Do we need proper replace semantic? This leads to issues in editor bindings because they don't switch source.
+    // this.ymodel.set('source', new Y.Text(value));
   }
   public updateSource(start: number, end: number, value = ''): void {
     this.ymodel.doc!.transact(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9517,15 +9517,10 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
-isomorphic.js@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.1.5.tgz#f210e58ba4c96978a991c443cf67283366e9b70f"
-  integrity sha512-MkX5lLQApx/8IAIU31PKvpAZosnu2Jqcj1rM8TzxyA4CR96tv3SgMKQNTCxL58G7696Q57zd7ubHV/hTg+5fNA==
-
 isomorphic.js@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.2.tgz#4c76fb70d3e207123dead08675ba97eb75f5615a"
-  integrity sha512-tWhdHK5vam77zCkNKjpI8vWSrcVmlBeJIlxXgTiGaapgifQr0CfLHuPqMiZhjrI/K71X/aXaJZqUbkHZzg06Hg==
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.4.tgz#24ca374163ae54a7ce3b86ce63b701b91aa84969"
+  integrity sha512-Y4NjZceAwaPXctwsHgNsmfuPxR8lJ3f8X7QTAkhltrX4oGIv+eTlgHLXn4tWysC9zGTi929gapnPp+8F8cg7nA==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -10361,7 +10356,7 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lib0@^0.2.33, lib0@^0.2.35:
+lib0@^0.2.35, lib0@^0.2.38:
   version "0.2.40"
   resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.40.tgz#7c89c2a7a89f9caaa0a04eaecb944d8e90a731b3"
   integrity sha512-bKJxwll8MdwTTL3Siut6L+FjyF5sewXRE7noDTsRquEYy3Xi1UjtdEMZu46iuTvw9nQ/9p+gKkh1GxL2Kdaphw==
@@ -16626,17 +16621,17 @@ xterm@~4.8.1:
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.8.1.tgz#155a1729a43e1a89b406524e22c5634339e39ca1"
   integrity sha512-ax91ny4tI5eklqIfH79OUSGE2PUX2rGbwONmB6DfqpyhSZO8/cf++sqiaMWEVCMjACyMfnISW7C3gGMoNvNolQ==
 
-y-codemirror@2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-2.0.9.tgz#3804c11736b53a71046c23efdbe81128cc850820"
-  integrity sha512-wSSQRGhHKtDdKKjPclhRM3TRg/d1s7kPdzV4nYmVeEsyOZgMWhFxr/23EdSll5r6XUzQ1C3M5YVEQ4SZzhsDDw==
+y-codemirror@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-2.1.0.tgz#905c85fececd6ffa784f9c4bcb69c22ff1ae696e"
+  integrity sha512-lwuXbZoUW1EmhSTFYR7Qkbi01ixn5/L2LpnZ/7/vSRcJL3PKnWLFJOxXdXTx6bNDGUjY8N0VjJe97fYL6ev00Q==
   dependencies:
-    lib0 "^0.2.33"
+    lib0 "^0.2.35"
 
-y-protocols@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.2.tgz#32c7a2f656b82f435058d28406aa51780a1eb486"
-  integrity sha512-V6ZAmokdogW52+VsIg/YC0R6CHWgG8/hjO3rYL10hAzeT5j464kDiRki31O+GzTj+dMgNYZNd6IDP9X35FLXrw==
+y-protocols@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.4.tgz#810978c6172474be87457c3bcd669e529c5ba3a1"
+  integrity sha512-5/Hd6DJ5Y2SlbqLIKq86BictdOS0iAcWJZCVop8MKqx0XWwA+BbMn4538n4Z0CGjFMUGnG1kGzagk3BKGz5SvQ==
   dependencies:
     lib0 "^0.2.35"
 
@@ -16742,9 +16737,9 @@ yarn@1.21.1:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.21.1.tgz#1d5da01a9a03492dc4a5957befc1fd12da83d89c"
   integrity sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==
 
-yjs@13.4.12:
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.4.12.tgz#74e7fe5adaeb0056f500ed3a6765f5de08abfaf1"
-  integrity sha512-ABmFknpmjcGOOWx6m4dTsjEWsN77+jHTI5DbjbwUu5t9ni1teUPOrdZtsNwQDuNPTdwGpiU9MJtIr7W6dgr9aw==
+yjs@^13.5.2:
+  version "13.5.2"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.2.tgz#b518be0df84164591f4cc774aa24468d288e0e75"
+  integrity sha512-X5vscuAhQIYf77xuNeJSlEiQZq0aUVtvs3x2X3//ZGpDqcWiR3D0H1XMDfEnNzdTMzuhfDBMMxSl70klD+0OXw==
   dependencies:
-    lib0 "^0.2.35"
+    lib0 "^0.2.38"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16737,9 +16737,9 @@ yarn@1.21.1:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.21.1.tgz#1d5da01a9a03492dc4a5957befc1fd12da83d89c"
   integrity sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==
 
-yjs@^13.5.2:
-  version "13.5.2"
-  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.2.tgz#b518be0df84164591f4cc774aa24468d288e0e75"
-  integrity sha512-X5vscuAhQIYf77xuNeJSlEiQZq0aUVtvs3x2X3//ZGpDqcWiR3D0H1XMDfEnNzdTMzuhfDBMMxSl70klD+0OXw==
+yjs@^13.5.3:
+  version "13.5.3"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.3.tgz#0efc5983ec287d24f4471f8f4184f9df80780835"
+  integrity sha512-LlkmCr68LCfkmoic6rBjDaD01vbdMhy07dXYo65sQ0wOYh8eylrU1b0lTo3YT/BmcyH5Jn4KewDxyJMsDwvERw==
   dependencies:
     lib0 "^0.2.38"


### PR DESCRIPTION
Builds on my previous PR #6.

I didn't realize that I broke the codemirror-package tests. When I rebuilt all packages, some tests started failing. This PR fixes those tests. 

I removed the functionality to replace the "source" for now. We can introduce it later when it is actually being used. In this context, we actually mean to update the source.