### PR TITLE
Implement docprovider

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,6 +2,7 @@ name: example-environment
 channels:
   - conda-forge
 dependencies:
+  - jupyterlab-link-share=0.2
   - jupyter-server-proxy
   - matplotlib-base
   - nodejs=14

--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -1,0 +1,79 @@
+import uuid
+import json
+import time
+
+from tornado.ioloop import IOLoop
+from tornado.websocket import WebSocketHandler
+
+acquireLockMessageType = 127
+releaseLockMessageType = 126
+requestInitializedContentMessageType = 125
+putInitializedContentMessageType = 124
+
+class YjsRoom:
+    def __init__(self):
+        self.lock = None
+        self.clients = {}
+        self.content = bytes([])
+
+class YJSEchoWS(WebSocketHandler):
+    rooms = {}
+
+    def open(self, guid):
+        #print("[YJSEchoWS]: open", guid)
+        cls = self.__class__
+        self.id = str(uuid.uuid4())
+        self.room_id = guid
+        room = cls.rooms.get(self.room_id)
+        if room == None:
+            room = YjsRoom()
+            cls.rooms[self.room_id] = room
+        room.clients[self.id] = ( IOLoop.current(), self.hook_send_message )
+        # Send SyncStep1 message (based on y-protocols)
+        self.write_message(bytes([0, 0, 1, 0]), binary=True)
+
+    def on_message(self, message):
+        #print("[YJSEchoWS]: message, ", message)
+        cls = self.__class__
+        room = cls.rooms.get(self.room_id)
+        if message[0] == acquireLockMessageType: # tries to acquire lock
+            if room.lock == None or time.time() - room.lock > 10:
+                lock = int(time.time())
+                print('Acquired new lock: ', lock)
+                room.lock = lock
+                # return acquired lock
+                self.write_message(bytes([acquireLockMessageType]) + lock.to_bytes(4, byteorder = 'little'), binary=True)
+        elif message[0] == releaseLockMessageType:
+            releasedLock = int.from_bytes(message[1:], byteorder = 'little')
+            print("trying release lock: ", releasedLock)
+            if room.lock == releasedLock:
+                print('released lock: ', room.lock)
+                room.lock = None
+        elif message[0] == requestInitializedContentMessageType:
+            print("client requested initial content")
+            self.write_message(bytes([requestInitializedContentMessageType]) + room.content, binary=True)
+        elif message[0] == putInitializedContentMessageType:
+            print("client put initialized content")
+            room.content = message[1:]
+        elif room:
+            for client_id, (loop, hook_send_message) in room.clients.items() :
+                if self.id != client_id :
+                    loop.add_callback(hook_send_message, message)
+
+    def on_close(self):
+        #print("[YJSEchoWS]: close")
+        cls = self.__class__
+        room = cls.rooms.get(self.room_id)
+        room.clients.pop(self.id)
+        if len(room.clients) == 0 :
+            cls.rooms.pop(self.room_id)
+            print("[YJSEchoWS]: close room " + self.room_id)
+
+        return True
+
+    def check_origin(self, origin):
+        #print("[YJSEchoWS]: check origin")
+        return True
+
+    def hook_send_message(self, msg):
+        self.write_message(msg, binary=True)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -30,6 +30,7 @@ from .debuglog import DebugLogFileMixin
 from .handlers.build_handler import Builder, BuildHandler, build_path
 from .handlers.error_handler import ErrorHandler
 from .handlers.extension_manager_handler import ExtensionHandler, ExtensionManager, extensions_handler_path
+from .handlers.yjs_echo_ws import YJSEchoWS
 
 DEV_NOTE = """You're running JupyterLab from source.
 If you're working on the TypeScript sources of JupyterLab, try running
@@ -656,6 +657,10 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         builder = Builder(self.core_mode, app_options=build_handler_options)
         build_handler = (build_path, BuildHandler, {'builder': builder})
         handlers.append(build_handler)
+
+        #YJS_Echo WS Handler
+        yjs_echo_handler = (r"/api/yjs/(.*)", YJSEchoWS)
+        handlers.append(yjs_echo_handler)
 
         errored = False
 

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -217,6 +217,11 @@ export namespace CodeEditor {
       nbcell: nbmodel.ISharedCodeCell,
       reinitialize: boolean
     ): void;
+
+    /**
+     * A signal emitted when the nbmodel/nbcell was switched.
+     */
+    nbmodelSwitched: ISignal<IModel, boolean>;
   }
 
   /**
@@ -247,6 +252,7 @@ export namespace CodeEditor {
 
       this.modelDB.createMap('selections');
     }
+    nbmodelSwitched = new Signal<this, boolean>(this);
 
     public switchSharedModel(
       nbcell: nbmodel.ISharedCodeCell,
@@ -259,8 +265,9 @@ export namespace CodeEditor {
       }
       this.nbcell.changed.disconnect(this._onSharedModelChanged, this);
       // clone nbcell to retrieve a shared (not standalone) nbcell
-      this.nbcell = this.nbcell.clone();
+      this.nbcell = nbcell as any;
       this.nbcell.changed.connect(this._onSharedModelChanged, this);
+      this.nbmodelSwitched.emit(true);
     }
 
     /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -132,12 +132,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       ...config
     });
     const editor = (this._editor = Private.createEditor(host, fullConfig));
-    this.yeditorBinding = USE_YCODEMIRROR_BINDING
-      ? new CodemirrorBinding(
-          (this.model.nbcell as nbmodel.YCodeCell).ymodel.get('source'),
-          editor
-        )
-      : null;
+    this.initializeEditorBinding();
+    // every time the nbmodel is switched, we need to re-initialize the editor binding
+    this.model.nbmodelSwitched.connect(this.initializeEditorBinding, this);
 
     const doc = editor.getDoc();
 
@@ -207,6 +204,16 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
         this.refresh();
       }
     });
+  }
+
+  private initializeEditorBinding() {
+    if (USE_YCODEMIRROR_BINDING) {
+      this.yeditorBinding?.destroy();
+      this.yeditorBinding = new CodemirrorBinding(
+        (this.model.nbcell as nbmodel.YCodeCell).ymodel.get('source'),
+        this.editor
+      );
+    }
   }
 
   private yeditorBinding: CodemirrorBinding | null;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -481,7 +481,8 @@ export class DocumentManager implements IDocumentManager {
       kernelPreference,
       modelDBFactory,
       setBusy: this._setBusy,
-      sessionDialogs: this._dialogs
+      sessionDialogs: this._dialogs,
+      collaborative: true
     });
     const handler = new SaveHandler({
       context,

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -38,7 +38,10 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "y-websocket": "^1.3.11"
+    "@jupyterlab/nbmodel": "^3.1.0-alpha.3",
+    "lib0": "~0.2.41",
+    "y-websocket": "^1.3.11",
+    "yjs": "^13.5.3"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",

--- a/packages/docprovider/src/index.ts
+++ b/packages/docprovider/src/index.ts
@@ -7,4 +7,16 @@
  * @module docprovider
  */
 
+export interface IProvider {
+  /**
+   * Resolves to true if the initial content has been initialized on the server. false otherwise.
+   */
+  requestInitialContent(): Promise<boolean>;
+  putInitializedState(): void;
+  acquireLock(): Promise<number>;
+  releaseLock(lock: number): void;
+  destroy(): void;
+}
+
 export * from './yprovider';
+export * from './mock';

--- a/packages/docprovider/src/mock.ts
+++ b/packages/docprovider/src/mock.ts
@@ -1,0 +1,19 @@
+import { IProvider } from './index';
+
+export class ProviderMock implements IProvider {
+  requestInitialContent(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+  putInitializedState(): void {
+    /* nop */
+  }
+  acquireLock(): Promise<number> {
+    return Promise.resolve(0);
+  }
+  releaseLock(lock: number): void {
+    /* nop */
+  }
+  destroy(): void {
+    /* nop */
+  }
+}

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -3,10 +3,142 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+import * as Y from 'yjs';
 import { WebsocketProvider } from 'y-websocket';
+import * as decoding from 'lib0/decoding.js';
+import * as encoding from 'lib0/encoding.js';
+import * as nbmodel from '@jupyterlab/nbmodel';
 
-export const DOC_PROVIDER_TYPE = 'ws_yjs';
+export class WebsocketProviderWithLocks extends WebsocketProvider {
+  constructor(url: string, guid: string, ynotebook: nbmodel.YNotebook) {
+    super(url, guid, ynotebook.ydoc, { awareness: ynotebook.awareness });
+    // Message handler that confirms when a lock has been acquired
+    this.messageHandlers[127] = (
+      encoder,
+      decoder,
+      provider,
+      emitSynced,
+      messageType
+    ) => {
+      const timestamp = decoding.readUint32(decoder);
+      console.log('Acquired lock!', timestamp);
+      const lockRequest = this.currentLockRequest;
+      this.currentLockRequest = null;
+      if (lockRequest) {
+        lockRequest.resolve(timestamp);
+      }
+    };
+    // Message handler that receives the initial content
+    this.messageHandlers[125] = (
+      encoder,
+      decoder,
+      provider,
+      emitSynced,
+      messageType
+    ) => {
+      const initialContent = decoding.readTailAsUint8Array(decoder);
+      // Apply data from server
+      if (initialContent.byteLength > 0) {
+        setTimeout(() => {
+          Y.applyUpdate(this.doc, initialContent);
+        }, 0);
+      }
+      console.log('Received initial content!', initialContent);
+      const initialContentRequest = this.initialContentRequest;
+      this.initialContentRequest = null;
+      if (initialContentRequest) {
+        initialContentRequest.resolve(initialContent.byteLength > 0);
+      }
+    };
+  }
 
-class YWebsocketProvider extends WebsocketProvider {}
+  private __sendMessage(message: Uint8Array): void {
+    // send once connected
+    const send = () => {
+      setTimeout(() => {
+        if (this.wsconnected) {
+          this.ws!.send(message);
+        } else {
+          this.once('status', send);
+        }
+      }, 0);
+    };
+    send();
+  }
 
-export default YWebsocketProvider;
+  /**
+   * Resolves to true if the initial content has been initialized on the server. false otherwise.
+   */
+  public requestInitialContent(): Promise<boolean> {
+    if (this.initialContentRequest) {
+      return this.initialContentRequest.promise;
+    }
+
+    let resolve: any, reject: any;
+    const promise: Promise<boolean> = new Promise((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+    this.initialContentRequest = { promise, resolve, reject };
+    this.__sendMessage(new Uint8Array([125]));
+
+    // Resolve with true if the server doesn't respond for some reason.
+    // In case of a connection problem, we don't want the user to re-initialize the window.
+    // Instead wait for y-websocket to connect to the server.
+    // @todo maybe we should reload instead..
+    setTimeout(() => resolve(false), 1000);
+    return promise;
+  }
+
+  public putInitializedState(): void {
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, 124);
+    encoding.writeUint8Array(encoder, Y.encodeStateAsUpdate(this.doc));
+    this.__sendMessage(encoding.toUint8Array(encoder));
+  }
+
+  public acquireLock(): Promise<number> {
+    if (this.currentLockRequest) {
+      return this.currentLockRequest.promise;
+    }
+    this.__sendMessage(new Uint8Array([127]));
+    // try to acquire lock in regular interval
+    const intervalID = setInterval(() => {
+      if (this.wsconnected) {
+        // try to acquire lock
+        this.ws!.send(new Uint8Array([127]));
+      }
+    }, 500);
+    let resolve: any, reject: any;
+    const promise: Promise<number> = new Promise((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+    this.currentLockRequest = { promise, resolve, reject };
+    const _finally = () => {
+      clearInterval(intervalID);
+    };
+    promise.then(_finally, _finally);
+    return promise;
+  }
+
+  releaseLock(lock: number): void {
+    const encoder = encoding.createEncoder();
+    // reply with release lock
+    encoding.writeVarUint(encoder, 126);
+    encoding.writeUint32(encoder, lock);
+    console.log('Releasing lock!', lock);
+    this.ws?.send(encoding.toUint8Array(encoder));
+  }
+
+  private currentLockRequest: {
+    promise: Promise<number>;
+    resolve: (lock: number) => void;
+    reject: () => void;
+  } | null = null;
+  private initialContentRequest: {
+    promise: Promise<boolean>;
+    resolve: (initialized: boolean) => void;
+    reject: () => void;
+  } | null = null;
+}

--- a/packages/docprovider/test/yprovider.spec.ts
+++ b/packages/docprovider/test/yprovider.spec.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DOC_PROVIDER_TYPE } from '../src';
+import { WebsocketProviderWithLocks } from '../src';
 
 describe('@jupyterlab/docprovider', () => {
   describe('docprovider', () => {
     it('should have a type', () => {
-      expect(DOC_PROVIDER_TYPE).toBe('ws_yjs');
+      expect(WebsocketProviderWithLocks).not.toBeUndefined();
     });
   });
 });

--- a/packages/docprovider/tsconfig.json
+++ b/packages/docprovider/tsconfig.json
@@ -5,5 +5,9 @@
     "rootDir": "src"
   },
   "include": ["src/*"],
-  "references": []
+  "references": [
+    {
+      "path": "../nbmodel"
+    }
+  ]
 }

--- a/packages/docprovider/tsconfig.test.json
+++ b/packages/docprovider/tsconfig.test.json
@@ -6,10 +6,16 @@
   },
   "references": [
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "."
     },
     {
       "path": "../../testutils"
+    },
+    {
+      "path": "../nbmodel"
     }
   ]
 }

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -59,7 +59,8 @@
     "@lumino/disposable": "^1.4.3",
     "@lumino/messaging": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
-    "@lumino/widgets": "^1.18.0"
+    "@lumino/widgets": "^1.18.0",
+    "yjs": "^13.5.3"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.3",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -47,6 +47,7 @@
     "@jupyterlab/codemirror": "^3.1.0-alpha.3",
     "@jupyterlab/coreutils": "^5.1.0-alpha.3",
     "@jupyterlab/docprovider": "^3.1.0-alpha.3",
+    "@jupyterlab/nbmodel": "^3.1.0-alpha.3",
     "@jupyterlab/observables": "^4.1.0-alpha.3",
     "@jupyterlab/rendermime": "^3.1.0-alpha.3",
     "@jupyterlab/rendermime-interfaces": "^3.1.0-alpha.3",

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -7,6 +7,10 @@ import {
   ServerConnection
 } from '@jupyterlab/services';
 
+import * as nbmodel from '@jupyterlab/nbmodel';
+
+import * as Y from 'yjs';
+
 import { PromiseDelegate, PartialJSONValue } from '@lumino/coreutils';
 
 import { IDisposable, DisposableDelegate } from '@lumino/disposable';
@@ -24,7 +28,7 @@ import {
   sessionContextDialogs
 } from '@jupyterlab/apputils';
 
-import { PathExt } from '@jupyterlab/coreutils';
+import { PathExt, URLExt } from '@jupyterlab/coreutils';
 
 import { IModelDB, ModelDB } from '@jupyterlab/observables';
 
@@ -38,7 +42,11 @@ import {
   TranslationBundle
 } from '@jupyterlab/translation';
 
-import { DOC_PROVIDER_TYPE } from '@jupyterlab/docprovider';
+import {
+  WebsocketProviderWithLocks,
+  IProvider,
+  ProviderMock
+} from '@jupyterlab/docprovider';
 
 import { DocumentRegistry } from './registry';
 
@@ -64,9 +72,6 @@ export class Context<
     const localPath = this._manager.contents.localPath(this._path);
     const lang = this._factory.preferredLanguage(PathExt.basename(localPath));
 
-    // @todo user docprovider
-    console.log('Use DocProvider', DOC_PROVIDER_TYPE);
-
     const dbFactory = options.modelDBFactory;
     if (dbFactory) {
       const localPath = manager.contents.localPath(this._path);
@@ -75,6 +80,17 @@ export class Context<
     } else {
       this._model = this._factory.createNew(lang);
     }
+
+    const ynotebook = this._model.nbmodel as nbmodel.YNotebook;
+    const ydoc = ynotebook.ydoc;
+    this.ydoc = ydoc;
+    this.ycontext = ydoc.getMap('context');
+    // @todo remove websocket provider - this should be handled by a separate plugin
+    const server = ServerConnection.makeSettings();
+    const url = URLExt.join(server.wsUrl, 'api/yjs');
+    this.provider = options.collaborative
+      ? new WebsocketProviderWithLocks(url, localPath, ynotebook)
+      : new ProviderMock();
 
     this._readyPromise = manager.ready.then(() => {
       return this._populatedPromise.promise;
@@ -199,6 +215,9 @@ export class Context<
       this._modelDB.dispose();
     }
     this._model.dispose();
+    this.provider.destroy();
+    this._model.nbmodel.dispose();
+    this.ydoc.destroy();
     this._disposed.emit(void 0);
     Signal.clearData(this);
   }
@@ -230,32 +249,49 @@ export class Context<
    * @returns a promise that resolves upon initialization.
    */
   initialize(isNew: boolean): Promise<void> {
-    if (isNew) {
-      this._model.initialize();
-      return this._save();
-    }
-    if (this._modelDB) {
-      return this._modelDB.connected.then(() => {
-        if (this._modelDB.isPrepopulated) {
-          this._model.initialize();
-          void this._save();
-          return void 0;
-        } else {
-          return this._revert(true);
-        }
-      });
-    } else {
-      return this._revert(true);
-    }
+    return this.provider.acquireLock().then((lock: number) => {
+      return this.provider
+        .requestInitialContent()
+        .then(contentIsInitialized => {
+          let promise;
+          if (isNew || contentIsInitialized) {
+            promise = this._save();
+          } else {
+            promise = this._revert();
+          }
+          // if save/revert completed successfully, we set the inialized content in the rtc server.
+          promise = promise.then(() => {
+            this.provider.putInitializedState();
+            this._model.initialize();
+          });
+          // make sure that the lock is released after the above operations are completed.
+          const finally_ = () => {
+            this.provider.releaseLock(lock);
+          };
+          promise.then(finally_, finally_);
+          return promise;
+        });
+    });
   }
 
   /**
    * Save the document contents to disk.
    */
   save(): Promise<void> {
-    return this.ready.then(() => {
-      return this._save();
-    });
+    return Promise.all([this.provider.acquireLock(), this.ready]).then(
+      ([lock]) => {
+        let promise = this._save();
+        // if save completed successfully, we set the inialized content in the rtc server.
+        promise = promise.then(() => {
+          this.provider.putInitializedState();
+        });
+        const finally_ = () => {
+          this.provider.releaseLock(lock);
+        };
+        promise.then(finally_, finally_);
+        return promise;
+      }
+    );
   }
 
   /**
@@ -313,9 +349,16 @@ export class Context<
    * Revert the document contents to disk contents.
    */
   revert(): Promise<void> {
-    return this.ready.then(() => {
-      return this._revert();
-    });
+    return Promise.all([this.provider.acquireLock(), this.ready]).then(
+      ([lock]) => {
+        const promise = this._revert();
+        const finally_ = () => {
+          this.provider.releaseLock(lock);
+        };
+        promise.then(finally_, finally_);
+        return promise;
+      }
+    );
   }
 
   /**
@@ -466,6 +509,7 @@ export class Context<
     };
     const mod = this._contentsModel ? this._contentsModel.last_modified : null;
     this._contentsModel = newModel;
+    this.ycontext.set('last_modified', newModel.last_modified);
     if (!mod || newModel.last_modified !== mod) {
       this._fileChanged.emit(newModel);
     }
@@ -646,7 +690,9 @@ export class Context<
         // (our last save)
         // In some cases the filesystem reports an inconsistent time,
         // so we allow 0.5 seconds difference before complaining.
-        const modified = this.contentsModel?.last_modified;
+        const ycontextModified = this.ycontext.get('last_modified');
+        // prefer using the timestamp from ycontext because it is more up to date
+        const modified = ycontextModified || this.contentsModel?.last_modified;
         const tClient = modified ? new Date(modified) : new Date();
         const tDisk = new Date(model.last_modified);
         if (modified && tDisk.getTime() - tClient.getTime() > 500) {
@@ -787,6 +833,10 @@ or load the version on disk (revert)?`,
     await this._maybeCheckpoint(true);
   }
 
+  private provider: IProvider;
+  private ydoc: Y.Doc;
+  private ycontext: Y.Map<string>;
+
   protected translator: ITranslator;
   private _trans: TranslationBundle;
   private _manager: ServiceManager.IManager;
@@ -824,6 +874,8 @@ export namespace Context {
      * A service manager instance.
      */
     manager: ServiceManager.IManager;
+
+    collaborative?: boolean;
 
     /**
      * The model factory used to create the model.
@@ -898,7 +950,7 @@ namespace Private {
   /**
    * A no-op function.
    */
-  export function noOp() {
+  export function noOp(): void {
     /* no-op */
   }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -718,7 +718,7 @@ export class Context<
     );
     const body = this._trans.__(
       `"%1" has changed on disk since the last time it was opened or saved.
-Do you want to overwrite the file on disk with the version open here, 
+Do you want to overwrite the file on disk with the version open here,
 or load the version on disk (revert)?`,
       this.path
     );

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -23,6 +23,8 @@ import { nullTranslator, ITranslator } from '@jupyterlab/translation';
 
 import { DocumentRegistry, IDocumentWidget } from './index';
 
+import * as nbmodel from '@jupyterlab/nbmodel';
+
 /**
  * The default implementation of a document model.
  */
@@ -36,7 +38,12 @@ export class DocumentModel
     super({ modelDB });
     this._defaultLang = languagePreference || '';
     this.value.changed.connect(this.triggerContentChange, this);
+    // A DocumentModel is a CodeCell and a nbmodel in one.
+    const cell = nbmodel.YCodeCell.create();
+    this.nbmodel.insertCell(0, cell);
+    this.switchSharedModel(cell, true);
   }
+  nbmodel = nbmodel.YNotebook.create();
 
   /**
    * A signal emitted when the document content changes.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -11,6 +11,8 @@ import {
   map
 } from '@lumino/algorithm';
 
+import * as nbmodel from '@jupyterlab/nbmodel';
+
 import { PartialJSONValue, ReadonlyPartialJSONValue } from '@lumino/coreutils';
 
 import { IDisposable, DisposableDelegate } from '@lumino/disposable';
@@ -789,6 +791,7 @@ export namespace DocumentRegistry {
      * is not recommended, and may produce unpredictable results.
      */
     readonly modelDB: IModelDB;
+    readonly nbmodel?: nbmodel.ISharedNotebook;
 
     /**
      * Serialize the model to a string.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -791,7 +791,7 @@ export namespace DocumentRegistry {
      * is not recommended, and may produce unpredictable results.
      */
     readonly modelDB: IModelDB;
-    readonly nbmodel?: nbmodel.ISharedNotebook;
+    readonly nbmodel: nbmodel.ISharedNotebook;
 
     /**
      * Serialize the model to a string.
@@ -1519,7 +1519,7 @@ namespace Private {
   /**
    * A no-op function.
    */
-  export function noOp() {
+  export function noOp(): void {
     /* no-op */
   }
 }

--- a/packages/docregistry/tsconfig.json
+++ b/packages/docregistry/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../docprovider"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {

--- a/packages/docregistry/tsconfig.test.json
+++ b/packages/docregistry/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../docprovider"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {
@@ -55,6 +58,9 @@
     },
     {
       "path": "../docprovider"
+    },
+    {
+      "path": "../nbmodel"
     },
     {
       "path": "../observables"

--- a/testutils/src/jest-config.ts
+++ b/testutils/src/jest-config.ts
@@ -14,7 +14,20 @@ module.exports = function (baseDir: string) {
     testTimeout: 10000,
     setupFiles: ['@jupyterlab/testutils/lib/jest-shim.js'],
     testPathIgnorePatterns: ['/lib/', '/node_modules/'],
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+    moduleFileExtensions: [
+      'ts',
+      'tsx',
+      'js',
+      'jsx',
+      'json',
+      'node',
+      'mjs',
+      'cjs'
+    ],
+    transformIgnorePatterns: [
+      '/node_modules/(?![lib0]).+\\.js$',
+      '/node_modules/(?![lib0]).+\\.cjs$'
+    ],
     reporters: ['default', 'jest-junit', 'jest-summary-reporter'],
     coverageReporters: ['json', 'lcov', 'text', 'html'],
     coverageDirectory: path.join(baseDir, 'coverage'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10508,7 +10508,7 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lib0@^0.2.31:
+lib0@^0.2.31, lib0@~0.2.41:
   version "0.2.41"
   resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.41.tgz#57e6e9ffa2eb7c621c891946d150af50fac035bc"
   integrity sha512-lZ0I6N81tIDgoPIlUTRhb6mNjPsG5BXIbaK/UbtjakcYnfR+O64bKtIrLXDDnfd7nAo4vpGeZ0mPzbTsNTREcg==


### PR DESCRIPTION
This PR makes notebooks collaborative. I added the `yjs_echo_server`, implemented the `docprovider`, and hooked it up to the `docregistry`. 

@echarles `docprovider` currently uses some native Yjs features. I ported that from my previous PR. We can abstract that into `docprovider`.

After a review, we could merge the PR and separate some work. (order based on priority)
* The tests are still running. But they now take much longer because `yjs_echo_server` is working in the background and is never killed. @echarles or @hbcarlos Could you look into that?
* The `docprovider` needs a better interface that also handles `context` information - i.e. the `modified` timestamp. This API probably also can handle file-type information (currently defined in `codeeditor`). @echarles Could you work on that? 
* The content of a text-files is neither synced nor initialized with content from the filesystem (when it is opened a second time). 
* An empty cell is added every time a browser opens a document. The fix for this issue can be ported from our first RTC attempt - Kevin / Eric / Carlos
* Sync Cell-metadata - Kevin / Eric
* Awareness needs to be implemented. - Kevin
* Shared UndoManager needs to be implemented.  - Kevin

