### PR TITLE
Cell metadata

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -49,6 +49,7 @@
     "@jupyterlab/coreutils": "^5.1.0-alpha.3",
     "@jupyterlab/filebrowser": "^3.1.0-alpha.3",
     "@jupyterlab/nbformat": "^3.1.0-alpha.3",
+    "@jupyterlab/nbmodel": "^3.1.0-alpha.3",
     "@jupyterlab/observables": "^4.1.0-alpha.3",
     "@jupyterlab/outputarea": "^3.1.0-alpha.3",
     "@jupyterlab/rendermime": "^3.1.0-alpha.3",

--- a/packages/cells/tsconfig.json
+++ b/packages/cells/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {
@@ -41,9 +44,6 @@
     },
     {
       "path": "../ui-components"
-    },
-    {
-      "path": "../nbmodel"
     }
   ]
 }

--- a/packages/cells/tsconfig.json
+++ b/packages/cells/tsconfig.json
@@ -41,6 +41,9 @@
     },
     {
       "path": "../ui-components"
+    },
+    {
+      "path": "../nbmodel"
     }
   ]
 }

--- a/packages/cells/tsconfig.test.json
+++ b/packages/cells/tsconfig.test.json
@@ -39,6 +39,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "."
     },
     {
@@ -79,6 +82,9 @@
     },
     {
       "path": "../ui-components"
+    },
+    {
+      "path": "../nbmodel"
     }
   ]
 }

--- a/packages/cells/tsconfig.test.json
+++ b/packages/cells/tsconfig.test.json
@@ -24,6 +24,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {
@@ -37,9 +40,6 @@
     },
     {
       "path": "../ui-components"
-    },
-    {
-      "path": "../nbmodel"
     },
     {
       "path": "."
@@ -69,6 +69,9 @@
       "path": "../nbformat"
     },
     {
+      "path": "../nbmodel"
+    },
+    {
       "path": "../observables"
     },
     {
@@ -82,9 +85,6 @@
     },
     {
       "path": "../ui-components"
-    },
-    {
-      "path": "../nbmodel"
     }
   ]
 }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -328,7 +328,7 @@ export namespace CodeEditor {
     nbcell = nbmodel.YCodeCell.createStandalone();
 
     /**
-     * A mutex to updated the nbcell model.
+     * A mutex to update the nbcell model.
      */
     protected readonly _mutex = nbmodel.createMutex();
 

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -182,6 +182,11 @@ export namespace CodeEditor {
     mimeTypeChanged: ISignal<IModel, IChangedArgs<string>>;
 
     /**
+     * A signal emitted when the nbcell was switched.
+     */
+    nbcellSwitched: ISignal<IModel, boolean>;
+
+    /**
      * The text stored in the model.
      */
     readonly value: IObservableString;
@@ -209,6 +214,7 @@ export namespace CodeEditor {
      * The shared model for the cell editor.
      */
     readonly nbcell: nbmodel.ISharedCodeCell;
+
     /**
      * When we initialize a cell model, we create a standalone nbcell that cannot be shared in a YNotebook.
      * Call this function to re-initialize the local representation based on a fresh nbcell.
@@ -218,10 +224,6 @@ export namespace CodeEditor {
       reinitialize: boolean
     ): void;
 
-    /**
-     * A signal emitted when the nbmodel/nbcell was switched.
-     */
-    nbmodelSwitched: ISignal<IModel, boolean>;
   }
 
   /**
@@ -252,7 +254,6 @@ export namespace CodeEditor {
 
       this.modelDB.createMap('selections');
     }
-    nbmodelSwitched = new Signal<this, boolean>(this);
 
     public switchSharedModel(
       nbcell: nbmodel.ISharedCodeCell,
@@ -267,7 +268,7 @@ export namespace CodeEditor {
       // clone nbcell to retrieve a shared (not standalone) nbcell
       this.nbcell = nbcell as any;
       this.nbcell.changed.connect(this._onSharedModelChanged, this);
-      this.nbmodelSwitched.emit(true);
+      this.nbcellSwitched.emit(true);
     }
 
     /**
@@ -277,7 +278,7 @@ export namespace CodeEditor {
      * or the modeldb change handler.
      */
     private _onSharedModelChanged(
-      _: any,
+      sender: nbmodel.ISharedCodeCell,
       change: nbmodel.CellChange<nbformat.ICodeCellMetadata>
     ): void {
       this._mutex(() => {
@@ -316,6 +317,11 @@ export namespace CodeEditor {
         }
       });
     }
+
+    /**
+     * A signal emitted when the nbcell was switched.
+     */
+     nbcellSwitched = new Signal<this, boolean>(this);
 
     /**
      * The shared model for the cell editor.

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -395,6 +395,7 @@ export namespace CodeEditor {
       mimeType: IObservableValue,
       args: ObservableValue.IChangedArgs
     ): void {
+      console.log('--- _onModelDBMimeTypeChanged', mimeType, args);
       this._mimeTypeChanged.emit({
         name: 'mimeType',
         oldValue: args.oldValue as string,

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -223,7 +223,6 @@ export namespace CodeEditor {
       nbcell: nbmodel.ISharedCodeCell,
       reinitialize: boolean
     ): void;
-
   }
 
   /**
@@ -275,9 +274,9 @@ export namespace CodeEditor {
      * We update the modeldb store when nbcell changes.
      * To ensure that we don't run into infinite loops, we wrap this call in a "mutex".
      * The "mutex" ensures that the wrapped code can only be executed by either the sharedModelChanged hander
-     * or the modeldb change handler.
+     * or the modelDB change handler.
      */
-    private _onSharedModelChanged(
+    protected _onSharedModelChanged(
       sender: nbmodel.ISharedCodeCell,
       change: nbmodel.CellChange<nbformat.ICodeCellMetadata>
     ): void {
@@ -321,7 +320,7 @@ export namespace CodeEditor {
     /**
      * A signal emitted when the nbcell was switched.
      */
-     nbcellSwitched = new Signal<this, boolean>(this);
+    nbcellSwitched = new Signal<this, boolean>(this);
 
     /**
      * The shared model for the cell editor.
@@ -331,7 +330,7 @@ export namespace CodeEditor {
     /**
      * A mutex to updated the nbcell model.
      */
-    private readonly _mutex = nbmodel.createMutex();
+    protected readonly _mutex = nbmodel.createMutex();
 
     /**
      * The underlying `IModelDB` instance in which model

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -134,7 +134,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     const editor = (this._editor = Private.createEditor(host, fullConfig));
     this.initializeEditorBinding();
     // every time the nbmodel is switched, we need to re-initialize the editor binding
-    this.model.nbmodelSwitched.connect(this.initializeEditorBinding, this);
+    this.model.nbcellSwitched.connect(this.initializeEditorBinding, this);
 
     const doc = editor.getDoc();
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -81,7 +81,7 @@ export class Context<
       this._model = this._factory.createNew(lang);
     }
 
-    const ynotebook = this._model.nbmodel as nbmodel.YNotebook;
+    const ynotebook = this._model.nbnotebook as nbmodel.YNotebook;
     const ydoc = ynotebook.ydoc;
     this.ydoc = ydoc;
     this.ycontext = ydoc.getMap('context');
@@ -216,7 +216,7 @@ export class Context<
     }
     this._model.dispose();
     this.provider.destroy();
-    this._model.nbmodel.dispose();
+    this._model.nbnotebook.dispose();
     this.ydoc.destroy();
     this._disposed.emit(void 0);
     Signal.clearData(this);

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -40,10 +40,9 @@ export class DocumentModel
     this.value.changed.connect(this.triggerContentChange, this);
     // A DocumentModel is a CodeCell and a nbmodel in one.
     const cell = nbmodel.YCodeCell.create();
-    this.nbmodel.insertCell(0, cell);
+    this.nbnotebook.insertCell(0, cell);
     this.switchSharedModel(cell, true);
   }
-  nbmodel = nbmodel.YNotebook.create();
 
   /**
    * A signal emitted when the document content changes.
@@ -164,6 +163,11 @@ export class DocumentModel
     this._contentChanged.emit(void 0);
     this.dirty = true;
   }
+
+  /**
+   * The shared notebook model.
+   */
+  readonly nbnotebook = nbmodel.YNotebook.create();
 
   private _defaultLang = '';
   private _dirty = false;

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -791,7 +791,11 @@ export namespace DocumentRegistry {
      * is not recommended, and may produce unpredictable results.
      */
     readonly modelDB: IModelDB;
-    readonly nbmodel: nbmodel.ISharedNotebook;
+
+    /**
+     * The shared notebook model.
+     */
+    readonly nbnotebook: nbmodel.ISharedNotebook;
 
     /**
      * Serialize the model to a string.

--- a/packages/nbmodel/package.json
+++ b/packages/nbmodel/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@jupyterlab/nbformat": "^3.1.0-alpha.3",
-    "@jupyterlab/observables": "^4.1.0-alpha.3",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/signaling": "^1.4.3",

--- a/packages/nbmodel/src/api.ts
+++ b/packages/nbmodel/src/api.ts
@@ -79,10 +79,14 @@ export type ISharedCell =
   | ISharedMarkdownCell
   | ISharedUnrecognizedCell;
 
+export interface ISharedBaseCellMetada extends nbformat.IBaseCellMetadata {
+  slideshow: PartialJSONObject;
+}
+
 /**
  * Implements an API for nbformat.IBaseCell.
  */
-export interface ISharedBaseCell<Metadata extends nbformat.IBaseCellMetadata>
+export interface ISharedBaseCell<Metadata extends ISharedBaseCellMetada>
   extends IDisposable {
   // @todo clone should only be available in the specific implementations i.e. ISharedCodeCell
   clone(): ISharedBaseCell<Metadata>;
@@ -104,8 +108,7 @@ export interface ISharedBaseCell<Metadata extends nbformat.IBaseCellMetadata>
  * Implements an API for nbformat.ICodeCell.
  */
 export interface ISharedCodeCell
-  extends ISharedBaseCell<nbformat.ICodeCellMetadata>,
-    IDisposable {
+  extends ISharedBaseCell<ISharedBaseCellMetada> {
   cell_type: 'code';
   /**
    * The code cell's prompt number. Will be null if the cell has not been run.
@@ -115,15 +118,14 @@ export interface ISharedCodeCell
    * Execution, display, or stream outputs.
    */
   getOutputs(): nbformat.IOutput[];
-  toJSON(): nbformat.ICodeCell;
+  toJSON(): nbformat.IBaseCell;
 }
 
 /**
  * Implements an API for nbformat.IMarkdownCell.
  */
 export interface ISharedMarkdownCell
-  extends ISharedBaseCell<nbformat.IRawCellMetadata>,
-    IDisposable {
+  extends ISharedBaseCell<ISharedBaseCellMetada> {
   /**
    * String identifying the type of cell.
    */
@@ -140,7 +142,7 @@ export interface ISharedMarkdownCell
  * Implements an API for nbformat.IRawCell.
  */
 export interface ISharedRawCell
-  extends ISharedBaseCell<nbformat.IRawCellMetadata>,
+  extends ISharedBaseCell<ISharedBaseCellMetada>,
     IDisposable {
   /**
    * String identifying the type of cell.
@@ -164,7 +166,7 @@ export type Delta<T> = Array<{ insert?: T; delete?: number; retain?: number }>;
  * @todo Is this needed?
  */
 export interface ISharedUnrecognizedCell
-  extends ISharedBaseCell<nbformat.IRawCellMetadata>,
+  extends ISharedBaseCell<ISharedBaseCellMetada>,
     IDisposable {
   cell_type: 'raw';
   toJSON(): nbformat.ICodeCell;

--- a/packages/nbmodel/src/api.ts
+++ b/packages/nbmodel/src/api.ts
@@ -11,8 +11,6 @@ import { ISignal } from '@lumino/signaling';
 
 import * as nbformat from '@jupyterlab/nbformat';
 
-import { Delta } from './utils';
-
 /**
  * This file defines the shared nbmodel types.
  *
@@ -152,6 +150,13 @@ export interface ISharedRawCell
   setAttachments(attchments: nbformat.IAttachments | undefined): void;
   toJSON(): nbformat.IRawCell;
 }
+
+/**
+ * Changes on Sequence-like data are expressed as Quill-inspired deltas.
+ *
+ * @source https://quilljs.com/docs/delta/
+ */
+export type Delta<T> = Array<{ insert?: T; delete?: number; retain?: number }>;
 
 /**
  * Implements an API for nbformat.IUnrecognizedCell.

--- a/packages/nbmodel/src/api.ts
+++ b/packages/nbmodel/src/api.ts
@@ -80,7 +80,7 @@ export type ISharedCell =
   | ISharedUnrecognizedCell;
 
 export interface ISharedBaseCellMetada extends nbformat.IBaseCellMetadata {
-  slideshow: PartialJSONObject;
+  [key: string]: any;
 }
 
 /**

--- a/packages/nbmodel/src/utils.ts
+++ b/packages/nbmodel/src/utils.ts
@@ -3,49 +3,9 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import {
-  IObservableJSON,
-  IObservableList,
-  IObservableString
-} from '@jupyterlab/observables';
-
 import * as Y from 'yjs';
 
 import * as nbmodel from './api';
-
-/**
- * Changes on Sequence-like data are expressed as Quill-inspired deltas.
- *
- * @source https://quilljs.com/docs/delta/
- */
-export type Delta<T> = Array<{ insert?: T; delete?: number; retain?: number }>;
-
-/**
- * @deprecated
- */
-export function asJsonChange(
-  cellChange: nbmodel.MapChange
-): IObservableJSON.IChangedArgs[] {
-  throw new Error('Method not implemented.');
-}
-
-/**
- * @deprecated
- */
-export function asStringChange(
-  delta: Delta<string>
-): IObservableString.IChangedArgs[] {
-  throw new Error('Method not implemented.');
-}
-
-/**
- * @deprecated
- */
-export function asListChange(
-  delta: Delta<Array<any>>
-): IObservableList.IChangedArgs<any>[] {
-  throw new Error('Method not implemented.');
-}
 
 export function convertYMapEventToMapChange(
   event: Y.YMapEvent<any>

--- a/packages/nbmodel/src/ymodel.ts
+++ b/packages/nbmodel/src/ymodel.ts
@@ -175,7 +175,7 @@ export class YNotebook implements nbmodel.ISharedNotebook {
   private _changed = new Signal<this, nbmodel.NotebookChange>(this);
 }
 
-export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
+export class YBaseCell<Metadata extends nbmodel.ISharedBaseCellMetada>
   implements nbmodel.ISharedBaseCell<Metadata> {
   constructor(ymodel: Y.Map<any>) {
     this.ymodel = ymodel;
@@ -312,7 +312,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
 }
 
 export class YCodeCell
-  extends YBaseCell<nbformat.ICodeCellMetadata>
+  extends YBaseCell<nbmodel.ISharedBaseCellMetada>
   implements nbmodel.ISharedCodeCell {
   get cell_type(): 'code' {
     return 'code';
@@ -362,7 +362,7 @@ export class YCodeCell
 }
 
 export class YRawCell
-  extends YBaseCell<nbformat.IRawCellMetadata>
+  extends YBaseCell<nbmodel.ISharedBaseCellMetada>
   implements nbmodel.ISharedRawCell {
   get cell_type(): 'raw' {
     return 'raw';
@@ -378,7 +378,7 @@ export class YRawCell
 }
 
 export class YMarkdownCell
-  extends YBaseCell<nbformat.IRawCellMetadata>
+  extends YBaseCell<nbmodel.ISharedBaseCellMetada>
   implements nbmodel.ISharedMarkdownCell {
   get cell_type(): 'markdown' {
     return 'markdown';

--- a/packages/nbmodel/src/ymodel.ts
+++ b/packages/nbmodel/src/ymodel.ts
@@ -5,13 +5,13 @@
 
 import { ISignal, Signal } from '@lumino/signaling';
 
+import * as Y from 'yjs';
+
 import * as nbformat from '@jupyterlab/nbformat';
 
 import * as nbmodel from './api';
 
-import { Delta } from './utils';
-
-import * as Y from 'yjs';
+import { Delta } from './api';
 
 // @ts-ignore
 import { Awareness } from 'y-protocols/dist/awareness.cjs';

--- a/packages/nbmodel/src/ymodel.ts
+++ b/packages/nbmodel/src/ymodel.ts
@@ -234,7 +234,7 @@ export class YBaseCell<Metadata extends nbmodel.ISharedBaseCellMetada>
     if (modelEvent && modelEvent.keysChanged.has('metadata')) {
       const change = modelEvent.changes.keys.get('metadata');
       changes.metadataChange = {
-        oldValue: change!.oldValue,
+        oldValue: change?.oldValue ? change!.oldValue : undefined,
         newValue: this.getMetadata()
       };
     }

--- a/packages/nbmodel/tsconfig.json
+++ b/packages/nbmodel/tsconfig.json
@@ -8,9 +8,6 @@
   "references": [
     {
       "path": "../nbformat"
-    },
-    {
-      "path": "../observables"
     }
   ]
 }

--- a/packages/nbmodel/tsconfig.test.json
+++ b/packages/nbmodel/tsconfig.test.json
@@ -9,9 +9,6 @@
       "path": "../nbformat"
     },
     {
-      "path": "../observables"
-    },
-    {
       "path": "."
     },
     {
@@ -19,9 +16,6 @@
     },
     {
       "path": "../nbformat"
-    },
-    {
-      "path": "../observables"
     }
   ]
 }

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -45,7 +45,7 @@ export class CellList implements IObservableUndoableList<ICellModel> {
     this._cellOrder.changed.connect(this._onOrderChanged, this);
     this.nbmodel = model;
     this.nbmodel.changed.connect(this.onSharedModelChanged, this);
-    this.changed.connect(this.onModeldbChanged, this);
+    this.changed.connect(this.onModelDBChanged, this);
   }
 
   type: 'List';
@@ -56,7 +56,7 @@ export class CellList implements IObservableUndoableList<ICellModel> {
    */
   private readonly _mutex = nbmodel.createMutex();
 
-  private onModeldbChanged(
+  private onModelDBChanged(
     self: CellList,
     change: IObservableList.IChangedArgs<ICellModel>
   ) {

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -82,7 +82,11 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
     const factory =
       options.contentFactory || NotebookModel.defaultContentFactory;
     this.contentFactory = factory.clone(this.modelDB.view('cells'));
-    this._cells = new CellList(this.modelDB, this.contentFactory, this.nbmodel);
+    this._cells = new CellList(
+      this.modelDB,
+      this.contentFactory,
+      this.nbnotebook
+    );
     this._trans = (options.translator || nullTranslator).load('jupyterlab');
     this._cells.changed.connect(this._onCellsChanged, this);
 
@@ -101,7 +105,11 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
    * The cell model factory for the notebook.
    */
   readonly contentFactory: NotebookModel.IContentFactory;
-  readonly nbmodel = nbmodel.YNotebook.create();
+
+  /**
+   * The shared notebook model.
+   */
+  readonly nbnotebook = nbmodel.YNotebook.create();
 
   /**
    * The metadata associated with the notebook.


### PR DESCRIPTION
## References

Fixes https://github.com/jupyter-rtc/jupyterlab/issues/16

The cell metadata (tags) are synced between 2 cells on the UI

## Code changes

This adds the needed event handler to sync both modelDB and sharedModel when a cell metadata is changed.

Other minor change ((no change in functionality): This PR also renames nmodel field to nbnotebook and move the Delta type definition to api.ts.

TODO: It looks like the slideshow_type attribue is not defined on the nbformat, whereas implemented in the UI.

@dmonad @hbcarlos  this is ready for review/merge.