### PR TITLE
test services

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -39,7 +39,7 @@
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "docs": "typedoc src",
     "prepublishOnly": "jlpm run build && webpack",
-    "test": "jest",
+    "test": "jest --detectOpenHandles",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",


### PR DESCRIPTION
## References
Fixes #12 

Sometimes there is an error with jest because JupyterLab doesn't shut down properly while running the test.
The option `--detectOpenHandles` prevents this.

## Code changes

N/A

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
