### PR TITLE
Remove buffer dependency from apputils

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -33,7 +33,7 @@ const MISSING: Dict<string[]> = {
 
 const UNUSED: Dict<string[]> = {
   // url is a polyfill for sanitize-html
-  '@jupyterlab/apputils': ['@types/react', 'buffer', 'url'],
+  '@jupyterlab/apputils': ['@types/react', 'url'],
   '@jupyterlab/application': ['@fortawesome/fontawesome-free'],
   '@jupyterlab/apputils-extension': ['es6-promise'],
   '@jupyterlab/builder': [

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -64,7 +64,6 @@
     "@lumino/virtualdom": "^1.8.0",
     "@lumino/widgets": "^1.19.0",
     "@types/react": "^17.0.0",
-    "buffer": "^5.6.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "sanitize-html": "~1.27.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,14 +4915,6 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-buffer@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
-  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"


### PR DESCRIPTION
Alternative to https://github.com/jupyter-rtc/jupyterlab/pull/38

Looks like `buffer` was added as a dependency to `@jupyterlab/apputils` in https://github.com/jupyterlab/jupyterlab/commit/7031c5aa7c4c3fb05e8bff9dbe626622714875f4 but might not be needed anymore.