### PR TITLE
Fix overwrite

### DIFF
--- a/jupyterlab/handlers/yjs_echo_ws.py
+++ b/jupyterlab/handlers/yjs_echo_ws.py
@@ -37,12 +37,12 @@ class YJSEchoWS(WebSocketHandler):
         cls = self.__class__
         room = cls.rooms.get(self.room_id)
         if message[0] == acquireLockMessageType: # tries to acquire lock
-            if room.lock == None or time.time() - room.lock > 10:
-                lock = int(time.time())
-                # print('Acquired new lock: ', lock)
-                room.lock = lock
+            now = int(time.time())
+            if room.lock == None or now - room.lock > 15: # no lock or timeout
+                room.lock = now
+                # print('Acquired new lock: ', room.lock)
                 # return acquired lock
-                self.write_message(bytes([acquireLockMessageType]) + lock.to_bytes(4, byteorder = 'little'), binary=True)
+                self.write_message(bytes([acquireLockMessageType]) + room.lock.to_bytes(4, byteorder = 'little'), binary=True)
         elif message[0] == releaseLockMessageType:
             releasedLock = int.from_bytes(message[1:], byteorder = 'little')
             # print("trying release lock: ", releasedLock)
@@ -61,7 +61,7 @@ class YJSEchoWS(WebSocketHandler):
                     loop.add_callback(hook_send_message, message)
 
     def on_close(self):
-        #print("[YJSEchoWS]: close")
+        # print("[YJSEchoWS]: close")
         cls = self.__class__
         room = cls.rooms.get(self.room_id)
         room.clients.pop(self.id)

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -258,17 +258,18 @@ export class Context<
     } else {
       promise = this._revert();
     }
-    // if save/revert completed successfully, we set the inialized content in the rtc server.
-    promise = promise.then(() => {
-      this._provider.putInitializedState();
-      this._model.initialize();
-    });
     // make sure that the lock is released after the above operations are completed.
     const finally_ = () => {
       this._provider.releaseLock(lock);
     };
-    promise.then(finally_, finally_);
-    return await promise;
+    // if save/revert completed successfully, we set the inialized content in the rtc server.
+    promise
+      .then(() => {
+        this._provider.putInitializedState();
+        this._model.initialize();
+      })
+      .then(finally_, finally_);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
Fixes document loss described by @fperez https://github.com/jupyterlab/jupyterlab/pull/10118#issuecomment-827219178 

I was able to reproduce the issue by

1. opening a document
1. waiting until the document automatically reconnects
2. opening a second window

⇒ There is a 50% chance that the local document is overwritten by the remote content.

I fixed this issue by handling some edge cases in the yjs_ws_server.