### PR TITLE
Default outputs to `[]`

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -615,7 +615,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
 
     this._modelDBMutex(() => {
       const sharedCell = this.sharedModel as models.ISharedCodeCell;
-      sharedCell.setOutputs(outputs);
+      sharedCell.setOutputs(outputs ?? []);
     });
     this._outputs = factory.createOutputArea({ trusted, values: outputs });
     this._outputs.changed.connect(this.onGenericChange, this);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Attempt at fixing the failing test in https://github.com/jupyterlab/jupyterlab/pull/10118:

https://github.com/jupyterlab/jupyterlab/pull/10118/checks?check_run_id=2543655472

The tests instantiate a new `CodeCellModel` without setting the `outputs`:

https://github.com/jupyter-rtc/jupyterlab/blob/f8dadeef4f219780b897ab512da276da5de597df/packages/cells/test/model.spec.ts#L368-L374

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes


<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
